### PR TITLE
Don't break drop long-running connections

### DIFF
--- a/adhoc-http.cabal
+++ b/adhoc-http.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-15.7
+resolver: lts-21.17
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -34,7 +34,8 @@ packages:
 # These entries can reference officially published versions as well as
 # forks / in-progress versions pinned to a git hash. For example:
 #
-# extra-deps:
+extra-deps:
+- snap-server-1.1.2.1@sha256:1472326ecc890c3af6cb88355d4fbfa2e64c6dce4c5a9c36b80af4ca8e36dc1a,15471
 # - acme-missiles-0.3
 # - git: https://github.com/commercialhaskell/stack.git
 #   commit: e7b331f14bcffb8367cd58fbfc8b40ec7642100a


### PR DESCRIPTION
By default incoming connections are dropped after 1 minute (60 seconds). Let's add an option to adjust this value. In case of large files or slow network, the default 60 seconds may not be enough. Luckily one can resume the download but not all HTTP clients are smart enough to do that.

I had an issue with the previous stack/ghc so I bumped LTS to the latest one.
```
ghc: panic! (the 'impossible' happened)
  (GHC version 8.8.3 for x86_64-unknown-linux):
	Prelude.chr: bad argument: 3179719811

Please report this as a GHC bug:  https://www.haskell.org/ghc/reportabug
```